### PR TITLE
Feature/fix flash messages tests

### DIFF
--- a/tests/cases/components/comments.test.php
+++ b/tests/cases/components/comments.test.php
@@ -332,7 +332,7 @@ class CommentsComponentTest extends CakeTestCase {
 		$this->assertNotEqual($created['Comment']['id'], 3);
 		ksort($result);
 		$this->assertEqual($result, $expected);
-		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), 'The Comment has been saved.');
+		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), __d('comments','The Comment has been saved.', true));
 		$this->assertEqual($this->Controller->redirectUrl, array('123', '#' => 'comment' . $created['Comment']['id']));
 		$this->assertEqual($this->Controller->Article->field('comments'), $oldCount + 1);
 		
@@ -383,7 +383,7 @@ class CommentsComponentTest extends CakeTestCase {
 		$this->assertNotEqual($created['Comment']['id'], 3);
 		ksort($result);
 		$this->assertEqual($result, $expected);
-		$this->assertEqual($this->Controller->viewVars['messageTxt'], 'The Comment has been saved.');
+		$this->assertEqual($this->Controller->viewVars['messageTxt'], __d('comments','The Comment has been saved.', true));
 		$this->assertEqual($this->Controller->redirectUrl, null);
 		$this->assertEqual($this->Controller->viewVars['redirect'], null);
 		//array('123', '#' => 'comment' . $created['Comment']['id'])
@@ -426,12 +426,12 @@ class CommentsComponentTest extends CakeTestCase {
 		$this->Controller->Comments->callback_toggleApprove(1, 1);
 		$comment = $this->Controller->Article->Comment->findById(1);
 		$this->assertEqual($comment['Comment']['approved'], 0);
-		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), 'The Comment status has been updated.');
+		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), __d('comments','The Comment status has been updated.', true));
 		$this->assertEqual($this->Controller->Article->field('comments'), $oldCount - 1);
 		$this->assertNull($this->Controller->redirectUrl);
 		
 		$this->Controller->Comments->callback_toggleApprove(1, 'unexisting-id');
-		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), 'Error appear during comment status update. Try later.');
+		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), __d('comments','Error appear during comment status update. Try later.',true));
 		$this->assertNull($this->Controller->redirectUrl);
 		
 		$this->__setupControllerData();
@@ -441,7 +441,7 @@ class CommentsComponentTest extends CakeTestCase {
 		$this->Controller->Comments->callback_view('flat');
 		$comment = $this->Controller->Article->Comment->findById(1);
 		$this->assertEqual($comment['Comment']['approved'], 1);
-		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), 'The Comment status has been updated.');
+		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), __d('comments','The Comment status has been updated.', true));
 		$this->assertEqual($this->Controller->Article->field('comments'), $oldCount);
 		$this->assertNull($this->Controller->redirectUrl);
 		$this->assertTrue(is_array($this->Controller->viewVars['commentsData']));
@@ -465,12 +465,12 @@ class CommentsComponentTest extends CakeTestCase {
 		$this->Controller->Comments->callback_delete(1, 1);
 		$comment = $this->Controller->Article->Comment->findById(1);
 		$this->assertFalse($comment);
-		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), 'The Comment has been deleted.');
+		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), __d('comments', 'The Comment has been deleted.', true));
 		$this->assertEqual($this->Controller->Article->field('comments'), $oldCount - 1);
 		$this->assertEqual($this->Controller->redirectUrl, array());
 		
 		$this->Controller->Comments->callback_delete(1, 'unexisting-id');
-		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), 'Error appear during comment deleting. Try later.');
+		$this->assertEqual($this->Controller->Session->read('Message.flash.message'), __d('comments', 'Error appear during comment deleting. Try later.', true));
 		$this->assertEqual($this->Controller->redirectUrl, array());
 		
 		$this->Controller->Session->delete('Message.flash.message');

--- a/tests/cases/controllers/comments_controller.test.php
+++ b/tests/cases/controllers/comments_controller.test.php
@@ -207,14 +207,14 @@ class CommentsControllerTest extends CakeTestCase {
 	public function testAdminSpam() {
 		$this->Comments->admin_spam('invalid-comment');
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Wrong comment id');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Wrong comment id', true));
 		$this->Comments->Session->delete('Message.flash.message');
 
 		$Article = ClassRegistry::init('Article');
 		$oldCount = array_shift(Set::extract($Article->read(array('Article.comments'), 1), '/Article/comments'));
 		$this->Comments->admin_spam(1);
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Antispam system informed about spam message.');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Antispam system informed about spam message.', true));
 		$commentFlag = $this->Comments->Comment->read(array('Comment.is_spam'), 1);
 		$this->assertEqual($commentFlag['Comment']['is_spam'], 'spammanual');
 		$newCount = array_shift(Set::extract($Article->read(array('Article.comments'), 1), '/Article/comments'));
@@ -230,14 +230,14 @@ class CommentsControllerTest extends CakeTestCase {
 	public function testAdminHam() {
 		$this->Comments->admin_ham('invalid-comment');
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Wrong comment id');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Wrong comment id', true));
 		$this->Comments->Session->delete('Message.flash.message');
 
 		$Article = ClassRegistry::init('Article');
 		$oldCount = array_shift(Set::extract($Article->read(array('Article.comments'), 2), '/Article/comments'));
 		$this->Comments->admin_ham(3);
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Antispam system informed about ham message.');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Antispam system informed about ham message.', true));
 		$commentFlag = $this->Comments->Comment->read(array('Comment.is_spam'), 3);
 		$this->assertEqual($commentFlag['Comment']['is_spam'], 'ham');
 		$newCount = array_shift(Set::extract($Article->read(array('Article.comments'), 2), '/Article/comments'));
@@ -253,7 +253,7 @@ class CommentsControllerTest extends CakeTestCase {
 	public function testAdminView() {
 		$this->Comments->admin_view('invalid-comment');
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Invalid Comment.');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Invalid Comment.', true));
 		$this->Comments->Session->delete('Message.flash.message');
 
 		$this->Comments->admin_view(1);
@@ -268,14 +268,14 @@ class CommentsControllerTest extends CakeTestCase {
 	public function testAdminDelete() {
 		$this->Comments->admin_delete('invalid-comment');
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Invalid id for Comment');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Invalid id for Comment', true));
 		$this->Comments->Session->delete('Message.flash.message');
 
 		$Article = ClassRegistry::init('Article');
 		$oldCount = array_shift(Set::extract($Article->read(array('Article.comments'), 1), '/Article/comments'));
 		$this->Comments->admin_delete(1);
 		$this->assertEqual($this->Comments->redirectUrl, array('action' => 'index'));
-		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), 'Comment deleted');
+		$this->assertEqual($this->Comments->Session->read('Message.flash.message'), __d('comments', 'Comment deleted', true));
 		$newCount = array_shift(Set::extract($Article->read(array('Article.comments'), 1), '/Article/comments'));
 		$this->assertEqual($newCount, $oldCount - 1);
 		$this->Comments->Session->delete('Message.flash.message');


### PR DESCRIPTION
Use gettext to allows tests to be valid in other languages in components and controller tests
