### PR TITLE
Fix Notice: Element Not Found

### DIFF
--- a/View/Helper/CommentWidgetHelper.php
+++ b/View/Helper/CommentWidgetHelper.php
@@ -223,8 +223,9 @@ class CommentWidgetHelper extends AppHelper {
  * @param array $params
  * @return string, rendered element
  */
-	public function element($name, $params = array(), $extra = array('plugin'=>'comments')) {
+	public function element($name, $params = array(), $extra = array()) {
 		$View = $this->__view();
+		$extra= array('plugin'=>'comments');
 		if (strpos($name, '/') === false) {
 			$name = 'comments/' . $this->globalParams['theme'] . '/' . $name;
 		}


### PR DESCRIPTION
Not sure is this the problem for anyone else, I've got these Notice in cakePHP 2.4.1, and fixed it by altering public function element.

Hmm, maybe a array_merge can be applied to it instead of direct assigning to the third param.

Fix Notice: Element Not Found: Elements\comments\flat\main.ctp,
Element Not Found: Elements\comments\flat\paginator.ctp
