### PR TITLE
Fix submodule url in Installation Docs

### DIFF
--- a/Docs/Documentation/Installation.md
+++ b/Docs/Documentation/Installation.md
@@ -9,7 +9,7 @@ Git Submodule
 If you're using git for version control, you may want to add the **Comments** plugin as a submodule on your repository. To do so, run the following command from the base of your repository:
 
 ```
-git submodule add git@github.com:CakeDC/search.git app/Plugin/Comments
+git submodule add git@github.com:CakeDC/comments.git app/Plugin/Comments
 ```
 
 After doing so, you will see the submodule in your changes pending, plus the file ```.gitmodules```. Simply commit and push to your repository.


### PR DESCRIPTION
Fixing a mistake that went unnoticed

![image](https://cloud.githubusercontent.com/assets/3277185/8474502/ee636c86-2086-11e5-9595-2678f2b009de.png)

![image](https://cloud.githubusercontent.com/assets/3277185/8474505/f380a0e4-2086-11e5-9070-f05f9f1779b8.png)
